### PR TITLE
Add TextureSet browser and reverse model lookup

### DIFF
--- a/odradek-app/src/main/java/module-info.java
+++ b/odradek-app/src/main/java/module-info.java
@@ -50,6 +50,7 @@ module odradek.app {
         sh.adelessfox.odradek.app.ui.component.bookmarks.menu.ToggleBookmarkAction,
         sh.adelessfox.odradek.app.ui.component.bookmarks.menu.RenameBookmarkAction,
         sh.adelessfox.odradek.app.ui.component.usages.menu.ShowUsagesAction,
+        sh.adelessfox.odradek.app.ui.component.usages.menu.FindContainingModelAction,
         sh.adelessfox.odradek.app.ui.menu.main.MainMenu.File,
         sh.adelessfox.odradek.app.ui.menu.main.MainMenu.Edit,
         sh.adelessfox.odradek.app.ui.menu.main.MainMenu.Help,
@@ -77,4 +78,5 @@ module odradek.app {
         with sh.adelessfox.odradek.app.util.steam.SteamGameLocator;
 
     uses sh.adelessfox.odradek.app.util.GameLocator;
+    uses sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
 }

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/main/MainEvent.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/main/MainEvent.java
@@ -12,4 +12,7 @@ public sealed interface MainEvent extends Event {
 
     record ShowUsages(ObjectId objectId) implements MainEvent {
     }
+
+    record ShowContainingModels(ObjectId objectId) implements MainEvent {
+    }
 }

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/main/MainView.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/main/MainView.java
@@ -5,6 +5,7 @@ import jakarta.inject.Singleton;
 import sh.adelessfox.odradek.app.ui.component.bookmarks.BookmarkToolPanel;
 import sh.adelessfox.odradek.app.ui.component.common.View;
 import sh.adelessfox.odradek.app.ui.component.graph.GraphPresenter;
+import sh.adelessfox.odradek.app.ui.component.texturesets.TextureSetBrowserPanel;
 import sh.adelessfox.odradek.app.ui.component.usages.UsagesToolPanel;
 import sh.adelessfox.odradek.event.EventBus;
 import sh.adelessfox.odradek.ui.components.tool.ToolPanelContainer;
@@ -19,6 +20,7 @@ public class MainView implements View<JComponent> {
     public static final String GRAPH_PANEL_ID = "graph";
     public static final String BOOKMARKS_PANEL_ID = "bookmarks";
     public static final String USAGES_PANEL_ID = "usages";
+    public static final String TEXTURESETS_PANEL_ID = "texturesets";
 
     private final JPanel root;
 
@@ -27,10 +29,11 @@ public class MainView implements View<JComponent> {
         GraphPresenter graphPresenter,
         BookmarkToolPanel bookmarkPanel,
         UsagesToolPanel usagesPanel,
+        TextureSetBrowserPanel textureSetBrowserPanel,
         EditorManager editorManager,
         EventBus eventBus
     ) {
-        var center = buildCenter(graphPresenter, bookmarkPanel, usagesPanel, editorManager, eventBus);
+        var center = buildCenter(graphPresenter, bookmarkPanel, usagesPanel, textureSetBrowserPanel, editorManager, eventBus);
         var right = buildRight();
         var bottom = buildBottom();
 
@@ -49,6 +52,7 @@ public class MainView implements View<JComponent> {
         GraphPresenter graphPresenter,
         BookmarkToolPanel bookmarkPanel,
         UsagesToolPanel usagesPanel,
+        TextureSetBrowserPanel textureSetBrowserPanel,
         EditorManager editorManager,
         EventBus eventBus
     ) {
@@ -56,6 +60,7 @@ public class MainView implements View<JComponent> {
         center.addPrimaryPanel(GRAPH_PANEL_ID, "Graph", Fugue.getIcon("blue-document"), graphPresenter.getView());
         center.addSecondaryPanel(BOOKMARKS_PANEL_ID, "Bookmarks", Fugue.getIcon("blue-document-bookmark"), bookmarkPanel);
         center.addSecondaryPanel(USAGES_PANEL_ID, "Usages", Fugue.getIcon("magnifier-left"), usagesPanel);
+        center.addSecondaryPanel(TEXTURESETS_PANEL_ID, "TextureSets", Fugue.getIcon("image"), textureSetBrowserPanel);
         center.setContent(editorManager.getRoot());
         center.showPanel(GRAPH_PANEL_ID);
 

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/texturesets/TextureSetBrowserPanel.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/texturesets/TextureSetBrowserPanel.java
@@ -1,0 +1,234 @@
+package sh.adelessfox.odradek.app.ui.component.texturesets;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sh.adelessfox.odradek.app.ui.component.main.MainEvent;
+import sh.adelessfox.odradek.app.ui.component.main.MainView;
+import sh.adelessfox.odradek.app.ui.menu.graph.GraphMenu;
+import sh.adelessfox.odradek.event.EventBus;
+import sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
+import sh.adelessfox.odradek.game.decima.DecimaGame;
+import sh.adelessfox.odradek.game.decima.ObjectId;
+import sh.adelessfox.odradek.game.decima.ObjectIdHolder;
+import sh.adelessfox.odradek.ui.actions.Actions;
+import sh.adelessfox.odradek.ui.components.SearchTextField;
+import sh.adelessfox.odradek.ui.components.tool.ToolPanel;
+import sh.adelessfox.odradek.ui.data.DataKeys;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+@Singleton
+public final class TextureSetBrowserPanel implements ToolPanel {
+    private static final Logger log = LoggerFactory.getLogger(TextureSetBrowserPanel.class);
+    private static final String TYPE_NAME = "TextureSet";
+
+    private final DecimaGame game;
+    private final EventBus eventBus;
+
+    private JComponent root;
+    private JList<Entry> list;
+    private DefaultListModel<Entry> model;
+    private volatile List<Entry> allEntries = List.of();
+    private String filterText = "";
+
+    @Inject
+    TextureSetBrowserPanel(DecimaGame game, EventBus eventBus) {
+        this.game = game;
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public JComponent createComponent() {
+        if (root != null) {
+            return root;
+        }
+
+        model = new DefaultListModel<>();
+        list = new JList<>(model);
+        list.setCellRenderer(new EntryRenderer());
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2 && SwingUtilities.isLeftMouseButton(e)) {
+                    var entry = list.getSelectedValue();
+                    if (entry != null) {
+                        eventBus.publish(new MainEvent.ShowPanel(MainView.USAGES_PANEL_ID));
+                        eventBus.publish(new MainEvent.ShowContainingModels(entry.objectId));
+                    }
+                }
+            }
+        });
+
+        Actions.installContextMenu(list, GraphMenu.ID, key -> {
+            if (DataKeys.GAME.is(key)) {
+                return Optional.of(game);
+            }
+            if (DataKeys.SELECTION.is(key)) {
+                var selected = list.getSelectedValue();
+                return selected == null ? Optional.empty() : Optional.of(selected);
+            }
+            return Optional.empty();
+        });
+
+        var filterField = new SearchTextField();
+        filterField.setPlaceholderText("Filter by name…");
+        filterField.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createMatteBorder(0, 0, 1, 0, UIManager.getColor("Component.borderColor")),
+            BorderFactory.createEmptyBorder(6, 8, 6, 8)
+        ));
+        filterField.addActionListener(_ -> {
+            filterText = filterField.getText().toLowerCase(Locale.ROOT);
+            applyFilter();
+        });
+
+        var statusLabel = new JLabel("Scanning TextureSets…");
+        statusLabel.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+
+        var panel = new JPanel(new BorderLayout());
+        panel.add(filterField, BorderLayout.NORTH);
+        panel.add(new JScrollPane(list), BorderLayout.CENTER);
+        panel.add(statusLabel, BorderLayout.SOUTH);
+
+        root = panel;
+
+        new LoadEntriesWorker(statusLabel).execute();
+
+        return root;
+    }
+
+    @Override
+    public boolean isFocused() {
+        return list != null && list.isFocusOwner();
+    }
+
+    @Override
+    public void setFocus() {
+        if (list != null) {
+            list.requestFocusInWindow();
+        }
+    }
+
+    private void applyFilter() {
+        model.clear();
+        if (filterText.isEmpty()) {
+            allEntries.forEach(model::addElement);
+            return;
+        }
+        for (Entry entry : allEntries) {
+            var name = entry.name;
+            if (name != null && name.toLowerCase(Locale.ROOT).contains(filterText)) {
+                model.addElement(entry);
+            }
+        }
+    }
+
+    private static final class Entry implements ObjectIdHolder {
+        final ObjectId objectId;
+        volatile String name; // null until lazily resolved
+
+        Entry(ObjectId objectId) {
+            this.objectId = objectId;
+        }
+
+        @Override
+        public ObjectId objectId() {
+            return objectId;
+        }
+    }
+
+    private static final class EntryRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value instanceof Entry e) {
+                var name = e.name;
+                if (name == null || name.isEmpty()) {
+                    setText("[" + e.objectId + "]  <unnamed>");
+                } else {
+                    setText(name + "    [" + e.objectId + "]");
+                }
+            }
+            return this;
+        }
+    }
+
+    private final class LoadEntriesWorker extends SwingWorker<List<Entry>, Entry> {
+        private final JLabel statusLabel;
+
+        LoadEntriesWorker(JLabel statusLabel) {
+            this.statusLabel = statusLabel;
+        }
+
+        @Override
+        protected List<Entry> doInBackground() {
+            var graph = game.streamingGraph();
+            var registry = ContainerTypeRegistry.lookup(game).orElse(null);
+            var entries = new ArrayList<Entry>();
+
+            for (var group : graph.groups()) {
+                var types = group.types();
+                for (int i = 0; i < types.size(); i++) {
+                    if (TYPE_NAME.equals(types.get(i).name())) {
+                        entries.add(new Entry(new ObjectId(group.id(), i)));
+                    }
+                }
+            }
+
+            allEntries = List.copyOf(entries);
+            SwingUtilities.invokeLater(TextureSetBrowserPanel.this::applyFilter);
+
+            if (registry == null) {
+                log.warn("No ContainerTypeRegistry available; TextureSet names will not be resolved");
+                return entries;
+            }
+
+            int resolved = 0;
+            for (Entry entry : entries) {
+                try {
+                    var object = game.readObject(entry.objectId);
+                    registry.nameOf(object).ifPresent(name -> entry.name = name);
+                } catch (Exception e) {
+                    log.debug("Failed to read TextureSet {}", entry.objectId, e);
+                }
+                resolved++;
+                if ((resolved & 0xff) == 0) {
+                    int snapshot = resolved;
+                    int total = entries.size();
+                    SwingUtilities.invokeLater(() -> {
+                        statusLabel.setText("Resolving names " + snapshot + "/" + total + "…");
+                        list.repaint();
+                    });
+                }
+            }
+
+            return entries;
+        }
+
+        @Override
+        protected void done() {
+            try {
+                var entries = get();
+                statusLabel.setText(entries.size() + " TextureSets");
+                list.repaint();
+                applyFilter();
+            } catch (InterruptedException e) {
+                log.debug("TextureSet enumeration interrupted", e);
+            } catch (ExecutionException e) {
+                log.error("Failed to enumerate TextureSets", e.getCause());
+                statusLabel.setText("Failed to load TextureSets");
+            }
+        }
+    }
+
+}

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/LinkDatabase.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/LinkDatabase.java
@@ -18,9 +18,13 @@ import wtf.reversed.toolbox.hash.HashCode;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 final class LinkDatabase implements Closeable {
@@ -82,11 +86,19 @@ final class LinkDatabase implements Closeable {
             .toList();
 
         log.debug("Scanning graph groups...");
+        int skipped = 0;
         for (int i = 0; i < graph.groups().size(); i++) {
             var group = graph.groups().get(i);
             progress.accept(i + 1, graph.groups().size());
 
-            var info = visitGroup(group, game);
+            GroupInfo info;
+            try {
+                info = visitGroup(group, game);
+            } catch (Exception e) {
+                skipped++;
+                log.warn("Skipping group {} due to read error: {}", group.id(), e.toString());
+                continue;
+            }
             for (int j = 0; j < info.objects().size(); j++) {
                 var object = info.objects().get(j);
                 for (Link link : object.out()) {
@@ -95,6 +107,9 @@ final class LinkDatabase implements Closeable {
                     links.get(targetObject).add(PackedLink.pack(group.id(), j, link.path()));
                 }
             }
+        }
+        if (skipped > 0) {
+            log.warn("Link database built with {} unreadable group(s) skipped", skipped);
         }
 
         log.debug("Serializing the database...");
@@ -139,6 +154,56 @@ final class LinkDatabase implements Closeable {
         var object = game.readObject(source);
         var info = visitObject(object);
         return info.out();
+    }
+
+    /**
+     * Reverse-BFS from {@code start} through incoming links, returning the first
+     * object encountered along each path whose type satisfies {@code isContainer}.
+     * The starting object itself is not considered a result even if it matches.
+     *
+     * @param start       the object to walk back from
+     * @param isContainer predicate identifying terminal "container" types
+     * @param maxDepth    maximum BFS depth (each hop is one incoming link)
+     * @param maxResults  upper bound on returned matches; traversal stops early
+     */
+    public List<ObjectId> findContainingObjects(
+        ObjectId start,
+        Predicate<ClassTypeInfo> isContainer,
+        int maxDepth,
+        int maxResults
+    ) throws IOException {
+        var graph = game.streamingGraph();
+        var visited = new HashSet<ObjectId>();
+        var queue = new ArrayDeque<Step>();
+        var results = new LinkedHashSet<ObjectId>();
+
+        visited.add(start);
+        queue.add(new Step(start, 0));
+
+        while (!queue.isEmpty() && results.size() < maxResults) {
+            var step = queue.poll();
+            if (step.depth > maxDepth) {
+                continue;
+            }
+            if (!step.objectId.equals(start)) {
+                var type = graph.group(step.objectId.groupId()).types().get(step.objectId.objectIndex());
+                if (isContainer.test(type)) {
+                    results.add(step.objectId);
+                    continue;
+                }
+            }
+            for (Link link : getIncomingLinks(step.objectId)) {
+                var parent = new ObjectId(link.groupId(), link.objectIndex());
+                if (visited.add(parent)) {
+                    queue.add(new Step(parent, step.depth + 1));
+                }
+            }
+        }
+
+        return List.copyOf(results);
+    }
+
+    private record Step(ObjectId objectId, int depth) {
     }
 
     public void close() throws IOException {

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesLabelProvider.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesLabelProvider.java
@@ -1,6 +1,10 @@
 package sh.adelessfox.odradek.app.ui.component.usages;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
 import sh.adelessfox.odradek.game.decima.DecimaGame;
+import sh.adelessfox.odradek.game.decima.ObjectId;
 import sh.adelessfox.odradek.rtti.ClassTypeInfo;
 import sh.adelessfox.odradek.ui.components.StyledFragment;
 import sh.adelessfox.odradek.ui.components.StyledText;
@@ -11,23 +15,24 @@ import javax.swing.*;
 import java.util.Optional;
 
 final class UsagesLabelProvider implements StyledTreeLabelProvider<UsagesStructure> {
+    private static final Logger log = LoggerFactory.getLogger(UsagesLabelProvider.class);
+
     private final DecimaGame game;
+    private final ContainerTypeRegistry registry;
 
     UsagesLabelProvider(DecimaGame game) {
         this.game = game;
+        this.registry = ContainerTypeRegistry.lookup(game).orElse(null);
     }
 
     @Override
     public Optional<StyledText> getStyledText(UsagesStructure element) {
         return switch (element) {
-            case UsagesStructure.Root _ -> Optional.empty();
+            case UsagesStructure.Root _, UsagesStructure.ContainersRoot _ -> Optional.empty();
             case UsagesStructure.Objects _ -> StyledText.builder()
                 .add("Object", StyledFragment.BOLD)
                 .build();
-            case UsagesStructure.Object(var object) -> StyledText.builder()
-                .add("[" + object.toString() + "]")
-                .add(" " + getType(object.groupId(), object.objectIndex()), StyledFragment.NAME)
-                .build();
+            case UsagesStructure.Object(var object) -> objectLabel(object);
             case UsagesStructure.Links(var type, var links) -> StyledText.builder()
                 .add(getText(type), StyledFragment.BOLD)
                 .add("  " + (links.size() == 1 ? "1 result" : links.size() + " results"), StyledFragment.GRAYED)
@@ -37,16 +42,42 @@ final class UsagesLabelProvider implements StyledTreeLabelProvider<UsagesStructu
                 .add(" " + getType(link.groupId(), link.objectIndex()), StyledFragment.NAME)
                 .add(" " + link.path(), StyledFragment.GRAYED)
                 .build();
+            case UsagesStructure.Containers(var containers) -> StyledText.builder()
+                .add("Containing models", StyledFragment.BOLD)
+                .add("  " + (containers.size() == 1 ? "1 result" : containers.size() + " results"), StyledFragment.GRAYED)
+                .build();
+            case UsagesStructure.Container(var object) -> objectLabel(object);
         };
     }
 
     @Override
     public Optional<Icon> getIcon(UsagesStructure element) {
         return switch (element) {
-            case UsagesStructure.Object _ -> Optional.of(Fugue.getIcon("blue-document"));
+            case UsagesStructure.Object _, UsagesStructure.Container _ -> Optional.of(Fugue.getIcon("blue-document"));
             case UsagesStructure.Link(var type, _) -> Optional.of(getIcon(type));
+            case UsagesStructure.Containers _ -> Optional.of(Fugue.getIcon("target"));
             default -> Optional.empty();
         };
+    }
+
+    private Optional<StyledText> objectLabel(ObjectId object) {
+        var builder = StyledText.builder()
+            .add("[" + object + "]")
+            .add(" " + getType(object.groupId(), object.objectIndex()).name(), StyledFragment.NAME);
+        resolveName(object).ifPresent(name -> builder.add(" " + name, StyledFragment.GRAYED));
+        return builder.build();
+    }
+
+    private Optional<String> resolveName(ObjectId object) {
+        if (registry == null) {
+            return Optional.empty();
+        }
+        try {
+            return registry.nameOf(game.readObject(object));
+        } catch (Exception e) {
+            log.debug("Failed to resolve name for {}", object, e);
+            return Optional.empty();
+        }
     }
 
     private static String getText(UsagesStructure.Type type) {

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesStructure.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesStructure.java
@@ -33,21 +33,30 @@ sealed interface UsagesStructure extends TreeStructure<UsagesStructure> {
                     .filter(n -> !(n instanceof Links links && links.links().isEmpty()))
                     .toList();
             }
+            case ContainersRoot(var object, var containers) -> List.of(
+                new Objects(object),
+                new Containers(containers)
+            );
             case Objects(var object) -> List.of(new Object(object));
             case Object _ -> List.of();
             case Links(var type, var links) -> links.stream()
                 .map(link -> new Link(type, link))
                 .toList();
             case Link _ -> List.of();
+            case Containers(var containers) -> containers.stream()
+                .map(Container::new)
+                .toList();
+            case Container _ -> List.of();
         };
     }
 
     @Override
     default boolean hasChildren() {
         return switch (this) {
-            case Root _, Objects _ -> true;
+            case Root _, ContainersRoot _, Objects _ -> true;
             case Links(_, var links) -> !links.isEmpty();
-            case Link _, Object _ -> false;
+            case Containers(var containers) -> !containers.isEmpty();
+            case Link _, Object _, Container _ -> false;
         };
     }
 
@@ -57,6 +66,9 @@ sealed interface UsagesStructure extends TreeStructure<UsagesStructure> {
     }
 
     record Root(LinkDatabase provider, ObjectId object) implements UsagesStructure {
+    }
+
+    record ContainersRoot(ObjectId object, List<ObjectId> containers) implements UsagesStructure {
     }
 
     record Objects(ObjectId object) implements UsagesStructure {
@@ -92,5 +104,11 @@ sealed interface UsagesStructure extends TreeStructure<UsagesStructure> {
         public int hashCode() {
             return java.util.Objects.hash(type, link);
         }
+    }
+
+    record Containers(List<ObjectId> objects) implements UsagesStructure {
+    }
+
+    record Container(ObjectId objectId) implements UsagesStructure, ObjectIdHolder {
     }
 }

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesToolPanel.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/UsagesToolPanel.java
@@ -14,6 +14,7 @@ import sh.adelessfox.odradek.app.ui.menu.graph.GraphMenu;
 import sh.adelessfox.odradek.event.DefaultEventBus;
 import sh.adelessfox.odradek.event.Event;
 import sh.adelessfox.odradek.event.EventBus;
+import sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
 import sh.adelessfox.odradek.game.decima.DecimaGame;
 import sh.adelessfox.odradek.game.decima.ObjectId;
 import sh.adelessfox.odradek.game.decima.ObjectIdHolder;
@@ -55,6 +56,7 @@ public final class UsagesToolPanel implements ToolPanel {
     private LinkDatabase database;
     private StructuredTree<UsagesStructure> tree;
     private ObjectId pendingObjectId;
+    private ObjectId pendingContainersObjectId;
 
     @Inject
     UsagesToolPanel(DecimaGame game, EventBus appEventBus, @Named("config") Path config) {
@@ -97,6 +99,10 @@ public final class UsagesToolPanel implements ToolPanel {
                         eventBus.publish(new Events.ShowObject(pendingObjectId, false));
                         pendingObjectId = null;
                     }
+                    if (pendingContainersObjectId != null) {
+                        eventBus.publish(new Events.ShowContainers(pendingContainersObjectId));
+                        pendingContainersObjectId = null;
+                    }
                 }
                 case Events.DatabaseNotLoaded e -> {
                     Dialogs.showExceptionDialog(panel, "Unable to load the link database", e.reason());
@@ -110,6 +116,10 @@ public final class UsagesToolPanel implements ToolPanel {
         appEventBus.subscribe(
             MainEvent.ShowUsages.class,
             event -> eventBus.publish(new Events.ShowObject(event.objectId(), true)));
+
+        appEventBus.subscribe(
+            MainEvent.ShowContainingModels.class,
+            event -> eventBus.publish(new Events.ShowContainers(event.objectId())));
 
         if (Files.exists(path)) {
             // Trigger loading immediately if database file already exists
@@ -191,6 +201,7 @@ public final class UsagesToolPanel implements ToolPanel {
         eventBus.subscribe(Events.ShowObject.class, event -> {
             if (database == null) {
                 pendingObjectId = event.objectId();
+                pendingContainersObjectId = null;
                 return;
             }
             tree.setModel(new StructuredTreeModel<>(new UsagesStructure.Root(database, event.objectId())));
@@ -198,6 +209,22 @@ public final class UsagesToolPanel implements ToolPanel {
             if (event.record()) {
                 addToQueue(event.objectId());
             }
+        });
+
+        eventBus.subscribe(Events.ShowContainers.class, event -> {
+            if (database == null) {
+                pendingContainersObjectId = event.objectId();
+                pendingObjectId = null;
+                return;
+            }
+            new FindContainersWorker(eventBus, database, game, event.objectId()).execute();
+        });
+
+        eventBus.subscribe(Events.ContainersFound.class, event -> {
+            tree.setModel(new StructuredTreeModel<>(
+                new UsagesStructure.ContainersRoot(event.objectId(), event.containers())));
+            tree.expand();
+            addToQueue(event.objectId());
         });
 
         var pane = new FlatScrollPane();
@@ -289,6 +316,12 @@ public final class UsagesToolPanel implements ToolPanel {
 
         record ShowObject(ObjectId objectId, boolean record) implements Events {
         }
+
+        record ShowContainers(ObjectId objectId) implements Events {
+        }
+
+        record ContainersFound(ObjectId objectId, List<ObjectId> containers) implements Events {
+        }
     }
 
     private static class LoadDatabaseWorker extends SwingWorker<LinkDatabase, Void> {
@@ -318,6 +351,44 @@ public final class UsagesToolPanel implements ToolPanel {
             } catch (ExecutionException e) {
                 log.debug("Failed to load link database", e.getCause());
                 eventBus.publish(new Events.DatabaseNotLoaded(e.getCause()));
+            }
+        }
+    }
+
+    private static class FindContainersWorker extends SwingWorker<List<ObjectId>, Void> {
+        private static final int MAX_DEPTH = 20;
+        private static final int MAX_RESULTS = 500;
+
+        private final EventBus eventBus;
+        private final LinkDatabase database;
+        private final DecimaGame game;
+        private final ObjectId objectId;
+
+        FindContainersWorker(EventBus eventBus, LinkDatabase database, DecimaGame game, ObjectId objectId) {
+            this.eventBus = eventBus;
+            this.database = database;
+            this.game = game;
+            this.objectId = objectId;
+        }
+
+        @Override
+        protected List<ObjectId> doInBackground() throws Exception {
+            var registry = ContainerTypeRegistry.lookup(game).orElse(null);
+            if (registry == null) {
+                log.warn("No ContainerTypeRegistry for game {} — cannot find containing models", game.getClass().getSimpleName());
+                return List.of();
+            }
+            return database.findContainingObjects(objectId, registry::isContainer, MAX_DEPTH, MAX_RESULTS);
+        }
+
+        @Override
+        protected void done() {
+            try {
+                eventBus.publish(new Events.ContainersFound(objectId, get()));
+            } catch (InterruptedException e) {
+                log.debug("Find containers interrupted", e);
+            } catch (ExecutionException e) {
+                log.error("Failed to find containing models for {}", objectId, e.getCause());
             }
         }
     }

--- a/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/menu/FindContainingModelAction.java
+++ b/odradek-app/src/main/java/sh/adelessfox/odradek/app/ui/component/usages/menu/FindContainingModelAction.java
@@ -1,0 +1,34 @@
+package sh.adelessfox.odradek.app.ui.component.usages.menu;
+
+import sh.adelessfox.odradek.app.ui.Application;
+import sh.adelessfox.odradek.app.ui.component.bookmarks.menu.BookmarkMenu;
+import sh.adelessfox.odradek.app.ui.component.main.MainEvent;
+import sh.adelessfox.odradek.app.ui.component.main.MainView;
+import sh.adelessfox.odradek.app.ui.menu.MenuIds;
+import sh.adelessfox.odradek.app.ui.menu.graph.GraphMenu;
+import sh.adelessfox.odradek.game.decima.ObjectIdHolder;
+import sh.adelessfox.odradek.ui.actions.Action;
+import sh.adelessfox.odradek.ui.actions.ActionContext;
+import sh.adelessfox.odradek.ui.actions.ActionContribution;
+import sh.adelessfox.odradek.ui.actions.ActionRegistration;
+import sh.adelessfox.odradek.ui.data.DataKeys;
+import sh.adelessfox.odradek.ui.editors.actions.EditorMenu;
+
+@ActionRegistration(text = "Find Containing &Model", icon = "fugue:target", keystroke = "alt shift F7")
+@ActionContribution(parent = GraphMenu.ID, group = MenuIds.GROUP_MISC)
+@ActionContribution(parent = EditorMenu.ID, group = MenuIds.GROUP_MISC)
+@ActionContribution(parent = BookmarkMenu.ID)
+public final class FindContainingModelAction extends Action {
+    @Override
+    public void perform(ActionContext context) {
+        var holder = context.get(DataKeys.SELECTION, ObjectIdHolder.class).orElseThrow();
+        var eventBus = Application.getInstance().events();
+        eventBus.publish(new MainEvent.ShowPanel(MainView.USAGES_PANEL_ID));
+        eventBus.publish(new MainEvent.ShowContainingModels(holder.objectId()));
+    }
+
+    @Override
+    public boolean isVisible(ActionContext context) {
+        return context.get(DataKeys.SELECTION, ObjectIdHolder.class).isPresent();
+    }
+}

--- a/odradek-game-decima/src/main/java/module-info.java
+++ b/odradek-game-decima/src/main/java/module-info.java
@@ -6,4 +6,6 @@ module odradek.game.decima {
 
     exports sh.adelessfox.odradek.game.decima.util;
     exports sh.adelessfox.odradek.game.decima;
+
+    uses sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
 }

--- a/odradek-game-decima/src/main/java/sh/adelessfox/odradek/game/decima/ContainerTypeRegistry.java
+++ b/odradek-game-decima/src/main/java/sh/adelessfox/odradek/game/decima/ContainerTypeRegistry.java
@@ -1,0 +1,45 @@
+package sh.adelessfox.odradek.game.decima;
+
+import sh.adelessfox.odradek.rtti.ClassTypeInfo;
+import sh.adelessfox.odradek.rtti.data.TypedObject;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * Per-game registry that identifies "top-level container" object types and resolves
+ * display names for named objects (e.g. TextureSet).
+ * <p>
+ * In Decima archives most object names are stripped at build time; only a handful of
+ * types (notably TextureSet) carry surviving names. To locate a model from a named
+ * texture, a reverse traversal stops once it reaches a "container" type that groups
+ * a renderable model. This SPI lets each game define its own set of container types.
+ */
+public interface ContainerTypeRegistry {
+    /** Returns true if this registry applies to the given game. */
+    boolean supports(DecimaGame game);
+
+    /**
+     * Type names (as reported by {@link ClassTypeInfo#name()}) that are considered
+     * top-level model containers — reverse BFS terminates when it reaches one.
+     */
+    Set<String> containerTypeNames();
+
+    /**
+     * Best-effort display name for an object. Returns empty if the object has no
+     * surviving name (which is the common case).
+     */
+    Optional<String> nameOf(TypedObject object);
+
+    default boolean isContainer(ClassTypeInfo type) {
+        return containerTypeNames().contains(type.name());
+    }
+
+    static Optional<ContainerTypeRegistry> lookup(DecimaGame game) {
+        return ServiceLoader.load(ContainerTypeRegistry.class).stream()
+            .map(ServiceLoader.Provider::get)
+            .filter(r -> r.supports(game))
+            .findFirst();
+    }
+}

--- a/odradek-game-ds2/src/main/java/module-info.java
+++ b/odradek-game-ds2/src/main/java/module-info.java
@@ -108,4 +108,7 @@ module odradek.game.ds2 {
 
     provides sh.adelessfox.odradek.game.Game.Provider with
         sh.adelessfox.odradek.game.ds2.game.DS2Game.Provider;
+
+    provides sh.adelessfox.odradek.game.decima.ContainerTypeRegistry with
+        sh.adelessfox.odradek.game.ds2.game.DS2ContainerTypeRegistry;
 }

--- a/odradek-game-ds2/src/main/java/sh/adelessfox/odradek/game/ds2/game/DS2ContainerTypeRegistry.java
+++ b/odradek-game-ds2/src/main/java/sh/adelessfox/odradek/game/ds2/game/DS2ContainerTypeRegistry.java
@@ -1,0 +1,39 @@
+package sh.adelessfox.odradek.game.ds2.game;
+
+import sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
+import sh.adelessfox.odradek.game.decima.DecimaGame;
+import sh.adelessfox.odradek.game.ds2.rtti.DS2;
+import sh.adelessfox.odradek.rtti.data.TypedObject;
+
+import java.util.Optional;
+import java.util.Set;
+
+public final class DS2ContainerTypeRegistry implements ContainerTypeRegistry {
+    private static final Set<String> CONTAINER_TYPES = Set.of(
+        "ArtPartsDataResource",
+        "ArtPartsCoverModelSettingResource"
+    );
+
+    @Override
+    public boolean supports(DecimaGame game) {
+        return game instanceof DS2Game;
+    }
+
+    @Override
+    public Set<String> containerTypeNames() {
+        return CONTAINER_TYPES;
+    }
+
+    @Override
+    public Optional<String> nameOf(TypedObject object) {
+        if (object instanceof DS2.TextureSet textureSet) {
+            for (var desc : textureSet.textureDesc()) {
+                var path = desc.path();
+                if (path != null && !path.isEmpty()) {
+                    return Optional.of(path.startsWith("work:") ? path.substring("work:".length()) : path);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/odradek-game-hfw/src/main/java/module-info.java
+++ b/odradek-game-hfw/src/main/java/module-info.java
@@ -113,4 +113,7 @@ module odradek.game.hfw {
 
     provides Game.Provider with
         sh.adelessfox.odradek.game.hfw.game.HFWGame.Provider;
+
+    provides sh.adelessfox.odradek.game.decima.ContainerTypeRegistry with
+        sh.adelessfox.odradek.game.hfw.game.HFWContainerTypeRegistry;
 }

--- a/odradek-game-hfw/src/main/java/sh/adelessfox/odradek/game/hfw/game/HFWContainerTypeRegistry.java
+++ b/odradek-game-hfw/src/main/java/sh/adelessfox/odradek/game/hfw/game/HFWContainerTypeRegistry.java
@@ -1,0 +1,42 @@
+package sh.adelessfox.odradek.game.hfw.game;
+
+import sh.adelessfox.odradek.game.decima.ContainerTypeRegistry;
+import sh.adelessfox.odradek.game.decima.DecimaGame;
+import sh.adelessfox.odradek.game.hfw.rtti.HFW;
+import sh.adelessfox.odradek.rtti.data.TypedObject;
+
+import java.util.Optional;
+import java.util.Set;
+
+public final class HFWContainerTypeRegistry implements ContainerTypeRegistry {
+    // HFW lacks DS2's ArtPartsDataResource grouping; the top-level renderable
+    // model containers are the skinned/static model resources directly. If a future
+    // higher-level grouping type is discovered (e.g. for outfits/prefabs), add it here.
+    private static final Set<String> CONTAINER_TYPES = Set.of(
+        "SkinnedModelResource",
+        "StaticModelResource"
+    );
+
+    @Override
+    public boolean supports(DecimaGame game) {
+        return game instanceof HFWGame;
+    }
+
+    @Override
+    public Set<String> containerTypeNames() {
+        return CONTAINER_TYPES;
+    }
+
+    @Override
+    public Optional<String> nameOf(TypedObject object) {
+        if (object instanceof HFW.TextureSet textureSet) {
+            for (var desc : textureSet.textureDesc()) {
+                var path = desc.path();
+                if (path != null && !path.isEmpty()) {
+                    return Optional.of(path.startsWith("work:") ? path.substring("work:".length()) : path);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds two related features to make finding a model from its (named) textures sane, plus a small reliability fix to `LinkDatabase`.

**TextureSet browser panel.** A new dockable secondary panel lists every TextureSet in the loaded archive with its surviving path name (from `TextureSetTextureDesc.path` minus the `work:` prefix), filterable by substring. Double-clicking a row fires a reverse BFS through the existing `LinkDatabase` incoming-link graph and surfaces every top-level model container that transitively references it — `ArtPartsDataResource`, `ArtPartsCoverModelSettingResource`, and variants for DS2.

**Find Containing Model action.** The same BFS is exposed as a right-click / `Alt+Shift+F7` action on any `ObjectIdHolder`. Useful when you're staring at a TextureSet, RenderEffect, mesh, or any node mid-chain and want to jump to the model that owns it.

**`LinkDatabase.build` fault tolerance.** A single bad group (e.g. the `Invalid boolean value: 111` reader error I hit on a current DS2 build) used to kill the whole scan. Now it logs and skips, and a final tally reports how many groups were lost. The reverse-BFS feature obviously depends on the database actually existing, so this was unblocking.

## Design notes

The list of "container" types is per-game and configurable via a new `ContainerTypeRegistry` SPI in `odradek-game-decima` (`ServiceLoader`-discovered). Each game module supplies its own implementation listing the types BFS should stop at; the same SPI's `nameOf(TypedObject)` resolves display names for nodes that carry surviving names (currently just `TextureSet`), and the Usages panel renders those names alongside the existing `[gid:idx]` + type labels — so this also makes TextureSets readable in the existing "Show Usages" view.

DS2 lists `ArtPartsDataResource` and `ArtPartsCoverModelSettingResource` as containers. HFW has no `ArtPartsDataResource` in its `types.json`, so the HFW registry starts with `SkinnedModelResource` and `StaticModelResource` as the closest equivalents — happy to refine based on review.

BFS bounds default to `maxDepth=20`, `maxResults=500`; both are constants in `UsagesToolPanel.FindContainersWorker`. The chain depth in DS2 is around 10 hops so the depth cap is roomy. Results are bounded mostly to keep wildly-shared TextureSets from spraying a thousand rows; happy to tune.

## Test plan
- [x] `./mvnw clean package` succeeds against JDK 25.
- [x] Manual: TextureSet panel populates and filters; double-click on `fgl_face_fuzzdeferred_v00_clr.psd` returns the correct ArtPartsDataResource group.
- [x] Manual: `LinkDatabase` scan completes despite the `Invalid boolean value: 111` group on the current DS2 build; WARN line lists the skipped group id.
- [ ] HFW container-type list verified by someone with HFW context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)