### PR TITLE
Add model bundle export (Cast + textures) for DS2

### DIFF
--- a/odradek-app/pom.xml
+++ b/odradek-app/pom.xml
@@ -65,6 +65,10 @@
         </dependency>
         <dependency>
             <groupId>sh.adelessfox</groupId>
+            <artifactId>odradek-export-bundle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>sh.adelessfox</groupId>
             <artifactId>odradek-export-cast</artifactId>
         </dependency>
         <dependency>

--- a/odradek-app/src/main/java/module-info.java
+++ b/odradek-app/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module odradek.app {
     requires jdk.attach;
 
     // Exporters
+    requires odradek.export.bundle;
     requires odradek.export.cast;
     requires odradek.export.dds;
     requires odradek.export.json;

--- a/odradek-export-bundle/pom.xml
+++ b/odradek-export-bundle/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>sh.adelessfox</groupId>
+        <artifactId>odradek</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>odradek-export-bundle</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>sh.adelessfox</groupId>
+            <artifactId>odradek-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>sh.adelessfox</groupId>
+            <artifactId>odradek-game</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/odradek-export-bundle/src/main/java/module-info.java
+++ b/odradek-export-bundle/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module odradek.export.bundle {
+    requires odradek.core;
+    requires odradek.game;
+    requires org.slf4j;
+
+    provides sh.adelessfox.odradek.game.Exporter with
+        sh.adelessfox.odradek.export.bundle.ModelBundleDdsExporter,
+        sh.adelessfox.odradek.export.bundle.ModelBundlePngExporter;
+}

--- a/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/AbstractModelBundleExporter.java
+++ b/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/AbstractModelBundleExporter.java
@@ -1,0 +1,64 @@
+package sh.adelessfox.odradek.export.bundle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sh.adelessfox.odradek.game.Exporter;
+import sh.adelessfox.odradek.game.ModelBundle;
+import sh.adelessfox.odradek.scene.Scene;
+import sh.adelessfox.odradek.texture.Texture;
+import sh.adelessfox.odradek.texture.TextureSet;
+import sh.adelessfox.odradek.util.Filenames;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+/**
+ * Common behaviour for bundle exporters: emits one Cast file plus every source texture
+ * from every TextureSet in the bundle. The texture format (DDS, PNG) is chosen by the
+ * concrete subclass.
+ */
+abstract class AbstractModelBundleExporter implements Exporter.OfMultipleOutputs<ModelBundle> {
+    private static final Logger log = LoggerFactory.getLogger(AbstractModelBundleExporter.class);
+    private static final String CAST_EXPORTER_ID = "model.cast";
+    private static final String MODEL_FILENAME = "model.cast";
+
+    /** Id of the per-texture exporter to delegate to (e.g. "image.dds", "image.png"). */
+    protected abstract String textureExporterId();
+
+    /** File extension for emitted textures, including the leading dot. */
+    protected abstract String textureExtension();
+
+    @Override
+    public Class<ModelBundle> supportedType() {
+        return ModelBundle.class;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void export(ModelBundle bundle, OutputProvider provider) throws IOException {
+        Exporter.OfSingleOutput<Scene> cast = (Exporter.OfSingleOutput<Scene>) Exporter.exporter(CAST_EXPORTER_ID)
+            .filter(e -> e instanceof Exporter.OfSingleOutput<?>)
+            .orElseThrow(() -> new IOException("Cast exporter (id=" + CAST_EXPORTER_ID + ") not available"));
+        cast.export(bundle.scene(), provider.channel(MODEL_FILENAME));
+
+        Exporter.OfSingleOutput<Texture> textureExporter = (Exporter.OfSingleOutput<Texture>) Exporter.exporter(textureExporterId())
+            .filter(e -> e instanceof Exporter.OfSingleOutput<?>)
+            .orElseThrow(() -> new IOException("Texture exporter (id=" + textureExporterId() + ") not available"));
+
+        var writtenNames = new HashSet<String>();
+        for (TextureSet set : bundle.textureSets()) {
+            for (TextureSet.SourceTexture source : set.sourceTextures()) {
+                var unpacked = set.unpack(source).orElse(null);
+                if (unpacked == null) {
+                    log.debug("Source texture {} ({}) not packed in any output texture; skipping", source.path(), source.type());
+                    continue;
+                }
+                var name = Filenames.withSuffix(source.path(), textureExtension());
+                if (!writtenNames.add(name)) {
+                    continue;
+                }
+                textureExporter.export(unpacked, provider.channel(name));
+            }
+        }
+    }
+}

--- a/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/ModelBundleDdsExporter.java
+++ b/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/ModelBundleDdsExporter.java
@@ -1,0 +1,30 @@
+package sh.adelessfox.odradek.export.bundle;
+
+import java.util.Optional;
+
+public final class ModelBundleDdsExporter extends AbstractModelBundleExporter {
+    @Override
+    public String id() {
+        return "model.bundle.dds";
+    }
+
+    @Override
+    public String name() {
+        return "Cast + DDS textures";
+    }
+
+    @Override
+    public Optional<String> icon() {
+        return Optional.of("fugue:paint-can");
+    }
+
+    @Override
+    protected String textureExporterId() {
+        return "image.dds";
+    }
+
+    @Override
+    protected String textureExtension() {
+        return ".dds";
+    }
+}

--- a/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/ModelBundlePngExporter.java
+++ b/odradek-export-bundle/src/main/java/sh/adelessfox/odradek/export/bundle/ModelBundlePngExporter.java
@@ -1,0 +1,30 @@
+package sh.adelessfox.odradek.export.bundle;
+
+import java.util.Optional;
+
+public final class ModelBundlePngExporter extends AbstractModelBundleExporter {
+    @Override
+    public String id() {
+        return "model.bundle.png";
+    }
+
+    @Override
+    public String name() {
+        return "Cast + PNG textures";
+    }
+
+    @Override
+    public Optional<String> icon() {
+        return Optional.of("fugue:paint-can");
+    }
+
+    @Override
+    protected String textureExporterId() {
+        return "image.png";
+    }
+
+    @Override
+    protected String textureExtension() {
+        return ".png";
+    }
+}

--- a/odradek-game-ds2/src/main/java/module-info.java
+++ b/odradek-game-ds2/src/main/java/module-info.java
@@ -104,7 +104,8 @@ module odradek.game.ds2 {
         sh.adelessfox.odradek.game.ds2.converters.texture.UITextureToTextureConverter,
         sh.adelessfox.odradek.game.ds2.converters.ShaderResourceToShaderConverter,
         sh.adelessfox.odradek.game.ds2.converters.StreamingDataSourceToBytesConverter,
-        sh.adelessfox.odradek.game.ds2.converters.TextureSetToTextureSetConverter;
+        sh.adelessfox.odradek.game.ds2.converters.TextureSetToTextureSetConverter,
+        sh.adelessfox.odradek.game.ds2.converters.ModelToModelBundleConverter;
 
     provides sh.adelessfox.odradek.game.Game.Provider with
         sh.adelessfox.odradek.game.ds2.game.DS2Game.Provider;

--- a/odradek-game-ds2/src/main/java/sh/adelessfox/odradek/game/ds2/converters/ModelToModelBundleConverter.java
+++ b/odradek-game-ds2/src/main/java/sh/adelessfox/odradek/game/ds2/converters/ModelToModelBundleConverter.java
@@ -1,0 +1,138 @@
+package sh.adelessfox.odradek.game.ds2.converters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sh.adelessfox.odradek.game.Converter;
+import sh.adelessfox.odradek.game.ModelBundle;
+import sh.adelessfox.odradek.game.decima.ObjectId;
+import sh.adelessfox.odradek.game.decima.ObjectIdHolder;
+import sh.adelessfox.odradek.game.ds2.game.DS2Game;
+import sh.adelessfox.odradek.game.ds2.rtti.DS2;
+import sh.adelessfox.odradek.rtti.AtomTypeInfo;
+import sh.adelessfox.odradek.rtti.ContainerTypeInfo;
+import sh.adelessfox.odradek.rtti.PointerTypeInfo;
+import sh.adelessfox.odradek.rtti.TypeInfo;
+import sh.adelessfox.odradek.rtti.data.TypedObject;
+import sh.adelessfox.odradek.rtti.util.PathTypeVisitor;
+import sh.adelessfox.odradek.rtti.util.TypePath;
+import sh.adelessfox.odradek.scene.Scene;
+import sh.adelessfox.odradek.texture.TextureSet;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Converts a DS2 model resource (ArtPartsDataResource, SkinnedModelResource, etc.) into a
+ * {@link ModelBundle}: the Scene produced by the normal mesh pipeline, plus every TextureSet
+ * reachable by walking outgoing references from the source object.
+ */
+public final class ModelToModelBundleConverter implements Converter<Object, ModelBundle, DS2Game> {
+    private static final Logger log = LoggerFactory.getLogger(ModelToModelBundleConverter.class);
+    private static final String TEXTURE_SET_TYPE = "TextureSet";
+
+    @Override
+    public boolean supports(TypeInfo info) {
+        Class<?> cls = info.type();
+        return DS2.StaticMeshResource.class.isAssignableFrom(cls)
+            || DS2.StaticMeshInstance.class.isAssignableFrom(cls)
+            || DS2.RegularSkinnedMeshResource.class.isAssignableFrom(cls)
+            || DS2.LodMeshResource.class.isAssignableFrom(cls)
+            || DS2.MultiMeshResource.class.isAssignableFrom(cls)
+            || DS2.BodyVariant.class.isAssignableFrom(cls)
+            || DS2.SkinnedModelResource.class.isAssignableFrom(cls)
+            || DS2.DestructibilityPart.class.isAssignableFrom(cls)
+            || DS2.ControlledEntityResource.class.isAssignableFrom(cls)
+            || DS2.PrefabResource.class.isAssignableFrom(cls)
+            || DS2.PrefabInstance.class.isAssignableFrom(cls)
+            || DS2.MockupGeometry.class.isAssignableFrom(cls)
+            || DS2.ArtPartsCoverModelSettingResource.class.isAssignableFrom(cls)
+            || DS2.ArtPartsModelResource.class.isAssignableFrom(cls)
+            || DS2.ArtPartsDataResource.class.isAssignableFrom(cls);
+    }
+
+    @Override
+    public Optional<ModelBundle> convert(Object object, DS2Game game) {
+        if (!(object instanceof TypedObject typed)) {
+            return Optional.empty();
+        }
+
+        var scene = Converter.convert(typed, Scene.class, game).orElse(null);
+        if (scene == null) {
+            return Optional.empty();
+        }
+
+        // Defer the BFS walk until the exporter actually asks for the textures.
+        return Optional.of(new ModelBundle(scene, () -> resolveTextureSets(typed, game)));
+    }
+
+    private static List<TextureSet> resolveTextureSets(TypedObject root, DS2Game game) {
+        var textureSetIds = collectReachableTextureSets(root, game);
+        var textureSets = new ArrayList<TextureSet>(textureSetIds.size());
+        for (ObjectId id : textureSetIds) {
+            try {
+                var tsObject = game.readObject(id);
+                Converter.convert(tsObject, TextureSet.class, game)
+                    .ifPresent(textureSets::add);
+            } catch (IOException e) {
+                log.warn("Failed to read TextureSet {}: {}", id, e.toString());
+            }
+        }
+        return textureSets;
+    }
+
+    private static Set<ObjectId> collectReachableTextureSets(TypedObject root, DS2Game game) {
+        var visited = new HashSet<ObjectId>();
+        var textureSets = new LinkedHashSet<ObjectId>();
+        var queue = new ArrayDeque<TypedObject>();
+        queue.add(root);
+
+        while (!queue.isEmpty()) {
+            var current = queue.poll();
+            var outgoing = new ArrayList<ObjectId>();
+            collectOutgoingPointers(current, outgoing);
+
+            for (ObjectId id : outgoing) {
+                if (!visited.add(id)) {
+                    continue;
+                }
+                var type = game.streamingGraph().group(id.groupId()).types().get(id.objectIndex());
+                if (TEXTURE_SET_TYPE.equals(type.name())) {
+                    textureSets.add(id);
+                    continue;
+                }
+                try {
+                    queue.add(game.readObject(id));
+                } catch (IOException e) {
+                    log.debug("Skipping unreadable object {} during TextureSet walk: {}", id, e.toString());
+                }
+            }
+        }
+
+        return textureSets;
+    }
+
+    private static void collectOutgoingPointers(TypedObject object, ArrayList<ObjectId> out) {
+        var visitor = new PathTypeVisitor<RuntimeException>() {
+            @Override
+            public void visitContainer(ContainerTypeInfo typeInfo, Object object1, TypePath.Builder builder) {
+                if (!(typeInfo.itemType() instanceof AtomTypeInfo)) {
+                    super.visitContainer(typeInfo, object1, builder);
+                }
+            }
+
+            @Override
+            public void visitPointer(PointerTypeInfo typeInfo, Object object1, TypePath.Builder builder) {
+                if (object1 instanceof ObjectIdHolder holder) {
+                    out.add(holder.objectId());
+                }
+            }
+        };
+        visitor.visit(object);
+    }
+}

--- a/odradek-game/src/main/java/sh/adelessfox/odradek/game/ModelBundle.java
+++ b/odradek-game/src/main/java/sh/adelessfox/odradek/game/ModelBundle.java
@@ -1,0 +1,45 @@
+package sh.adelessfox.odradek.game;
+
+import sh.adelessfox.odradek.scene.Scene;
+import sh.adelessfox.odradek.texture.TextureSet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * A model paired with every TextureSet reachable from its source object.
+ * Used by bundle exporters that write a mesh file alongside its textures.
+ * <p>
+ * The texture-set list is resolved lazily on first call to {@link #textureSets()}
+ * — collecting them can be expensive (a transitive ref walk), and we only want to
+ * pay that cost when the user actually triggers an export.
+ */
+public final class ModelBundle {
+    private final Scene scene;
+    private final Supplier<List<TextureSet>> textureSetSupplier;
+    private volatile List<TextureSet> resolved;
+
+    public ModelBundle(Scene scene, Supplier<List<TextureSet>> textureSetSupplier) {
+        this.scene = Objects.requireNonNull(scene, "scene");
+        this.textureSetSupplier = Objects.requireNonNull(textureSetSupplier, "textureSetSupplier");
+    }
+
+    public Scene scene() {
+        return scene;
+    }
+
+    public List<TextureSet> textureSets() {
+        var local = resolved;
+        if (local == null) {
+            synchronized (this) {
+                local = resolved;
+                if (local == null) {
+                    local = List.copyOf(textureSetSupplier.get());
+                    resolved = local;
+                }
+            }
+        }
+        return local;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
         <module>odradek-app</module>
         <module>odradek-core</module>
+        <module>odradek-export-bundle</module>
         <module>odradek-export-cast</module>
         <module>odradek-export-dds</module>
         <module>odradek-export-json</module>
@@ -142,6 +143,11 @@
             </dependency>
 
             <!-- Export -->
+            <dependency>
+                <groupId>sh.adelessfox</groupId>
+                <artifactId>odradek-export-bundle</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>sh.adelessfox</groupId>
                 <artifactId>odradek-export-cast</artifactId>


### PR DESCRIPTION
## Summary

When you export a model as Cast today, you get the geometry and per-material mesh pieces — but the actual textures live behind ~10 ref hops the user has to walk by hand for every model. This change adds two new export formats — **Cast + DDS textures** and **Cast + PNG textures** — that ship the Cast file alongside every TextureSet transitively reachable from the source object, preserving the surviving directory tree from `TextureSetTextureDesc.path`:

```
<export-root>/<ObjectType_g_i>/
  model.cast
  ds/models/characters/fgl_fragile/fgl_textures/textures/
    fgl_body_boots_v00_clr.dds
    fgl_face_fuzzdeferred_v00_clr.dds   ← variation textures included
    ...
```

Variation TextureSets (e.g. muddy face via `ArtPartsVariationReplaceTextureSetResource`) come along automatically because they're reachable via outgoing refs.

## Design notes

- **No duplicated serialization.** The bundle exporters delegate to the existing single-file Cast / DDS / PNG exporters by id via the `Exporter` SPI. `AbstractModelBundleExporter` is the shared orchestration; concrete subclasses only declare which texture exporter id to use and which extension to emit.
- **Lazy texture walk.** `ModelBundle` holds a memoized `Supplier<List<TextureSet>>` rather than an eager list. `ModelToModelBundleConverter.convert()` only does the Scene conversion (delegating to the existing converter) and packages the supplier — the BFS runs only when `bundle.textureSets()` is called inside the exporter. This matters because anything that probes converters eagerly (action visibility checks, viewer discovery, etc.) shouldn't pay the walk cost.
- **DS2-only.** HFW lacks `ArtPartsDataResource` and its model containers differ enough that a separate implementation is warranted later. The intermediate `ModelBundle` type lives in `odradek-game` so a future HFW converter can reuse it.
- **Dedup.** Same source-texture path is written at most once per bundle.
- **No material binding in Cast.** Cast supports it; the existing exporter writes geometry only. Out of scope here — the per-material mesh split means manual assignment in Blender is one selection per material, which is bearable.

## Test plan
- [x] `./mvnw clean package` succeeds against JDK 25.
- [x] Manual: export an ArtPartsDataResource as "Cast + DDS textures" produces `model.cast` plus the expected `ds/models/...` tree.
- [x] Manual: variation TextureSets are bundled (verified by checking that a character with body-state variants gets multiple albedo maps).
- [x] Manual: app remains responsive when opening model editors — the walk is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)